### PR TITLE
Enable npm test with basic DOM tests

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -63,11 +63,18 @@ function toggleFullscreen() {
   }
 }
 
-document.addEventListener("fullscreenchange", () => {
-  const fullscreenBtn = document.getElementById("fullscreen-btn");
-  if (document.fullscreenElement) {
-    fullscreenBtn.textContent = "🗗 Exit Fullscreen";
-  } else {
-    fullscreenBtn.textContent = "🔳 Fullscreen";
-  }
-});
+if (typeof document !== "undefined") {
+  document.addEventListener("fullscreenchange", () => {
+    const fullscreenBtn = document.getElementById("fullscreen-btn");
+    if (document.fullscreenElement) {
+      fullscreenBtn.textContent = "🗗 Exit Fullscreen";
+    } else {
+      fullscreenBtn.textContent = "🔳 Fullscreen";
+    }
+  });
+}
+
+// Expose functions for testing in Node environments
+if (typeof module !== "undefined") {
+  module.exports = { loadGame, returnToMenu, toggleFullscreen };
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "web_game",
+  "version": "1.0.0",
+  "description": "Web game project",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -1,0 +1,42 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { loadGame, returnToMenu } = require('../js/main.js');
+
+test('loadGame loads a game and updates DOM', () => {
+  const elements = {
+    '.game-menu': { style: { display: 'grid' } },
+    'game-container': { style: { display: 'none' } },
+    'game-frame': { src: '' },
+    'current-game-title': { textContent: '' }
+  };
+  global.document = {
+    querySelector: (sel) => elements[sel],
+    getElementById: (id) => elements[id]
+  };
+  loadGame('dodge-the-poop');
+  assert.strictEqual(elements['.game-menu'].style.display, 'none');
+  assert.strictEqual(elements['game-container'].style.display, 'block');
+  assert.ok(elements['game-frame'].src.includes('games/dodge-the-poop/index.html'));
+  assert.strictEqual(elements['current-game-title'].textContent, 'Dodge the Poop');
+  delete global.document;
+});
+
+test('returnToMenu resets the game view', () => {
+  const elements = {
+    '.game-menu': { style: { display: 'none' } },
+    'game-container': { style: { display: 'block' } },
+    'game-frame': { src: 'something' }
+  };
+  const doc = {
+    querySelector: (sel) => elements[sel],
+    getElementById: (id) => elements[id],
+    exitFullscreen: () => { doc.fullscreenElement = null; },
+    fullscreenElement: null
+  };
+  global.document = doc;
+  returnToMenu();
+  assert.strictEqual(elements['game-container'].style.display, 'none');
+  assert.strictEqual(elements['.game-menu'].style.display, 'grid');
+  assert.strictEqual(elements['game-frame'].src, '');
+  delete global.document;
+});


### PR DESCRIPTION
## Summary
- expose JS functions for Node tests and guard browser-only event listener
- add package.json that runs the Node test runner
- add tests for `loadGame` and `returnToMenu`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689823c5479c832ea53ee343284a07f1