### PR TITLE
Add simple HTTP server and start script

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ web_game/
 
 Simply open `index.html` in any modern web browser. No installation or build process required!
 
+### Run with a Local Server
+
+1. Install dependencies with `npm install`
+2. Start the server using `npm start`
+3. Visit http://localhost:3000 in your browser
+
 ## Browser Compatibility
 
 - Chrome (recommended)

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "Web game project",
   "scripts": {
+    "start": "node server.js",
     "test": "node --test"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,0 +1,38 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const PORT = process.env.PORT || 3000;
+const mimeTypes = {
+  '.html': 'text/html',
+  '.js': 'application/javascript',
+  '.css': 'text/css',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.svg': 'image/svg+xml'
+};
+
+http.createServer((req, res) => {
+  const filePath = path.join(__dirname, req.url === '/' ? '/index.html' : req.url);
+  const ext = path.extname(filePath).toLowerCase();
+  const contentType = mimeTypes[ext] || 'application/octet-stream';
+
+  fs.readFile(filePath, (err, content) => {
+    if (err) {
+      if (err.code === 'ENOENT') {
+        res.writeHead(404);
+        res.end('Not Found');
+      } else {
+        res.writeHead(500);
+        res.end('Server Error');
+      }
+    } else {
+      res.writeHead(200, { 'Content-Type': contentType });
+      res.end(content);
+    }
+  });
+}).listen(PORT, () => {
+  console.log(`Server running at http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add Node HTTP server for serving static files
- document local server usage in README
- expose `npm start` script for running the server

## Testing
- `npm test`
- `node server.js` (start/stop)

------
https://chatgpt.com/codex/tasks/task_e_6898281a7344832e977b34ae069e13b3